### PR TITLE
Enable trivy scan by default

### DIFF
--- a/.github/workflows/create-push-image.yml
+++ b/.github/workflows/create-push-image.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
     inputs:
-      ignore_trivy_scan:
+      fail_trivy_scan:
         type: boolean
         description: Fail the build if vulnerabilities are found
         required: true 
@@ -52,11 +52,11 @@ jobs:
 
       - name: Set Trivy exit code
         run: |
-            if  [[ ${{ inputs.ignore_trivy_scan }} == true ]];
+            if  [[ ${{ inputs.fail_trivy_scan }} == true ]];
             then
-                echo 'TRIVY_EXIT_CODE=0' >> $GITHUB_ENV
-            else
                 echo 'TRIVY_EXIT_CODE=1' >> $GITHUB_ENV
+            else
+                echo 'TRIVY_EXIT_CODE=0' >> $GITHUB_ENV
             fi
 
       - name: Run Trivy vulnerability scanner

--- a/.github/workflows/create-push-image.yml
+++ b/.github/workflows/create-push-image.yml
@@ -9,9 +9,9 @@ on:
     inputs:
       ignore_trivy_scan:
         type: boolean
-        description: Ignore vulnerabilities if they are found
+        description: Fail the build if vulnerabilities are found
         required: true 
-        default: false
+        default: true
 
 jobs:
   build-and-push:


### PR DESCRIPTION
This PR is used enable the trivy scan by default. So it will try to fail the build in case of critical errors.